### PR TITLE
Reduce silero CPU usage

### DIFF
--- a/homeassistant_satellite/vad.py
+++ b/homeassistant_satellite/vad.py
@@ -33,11 +33,13 @@ class SileroVoiceActivityDetector(VoiceActivityDetector):
 
         onnx_path = str(onnx_path)
 
+        opts = onnxruntime.SessionOptions()
+        opts.inter_op_num_threads = 1
+        opts.intra_op_num_threads = 1
+
         self.session = onnxruntime.InferenceSession(
-            onnx_path, providers=["CPUExecutionProvider"]
+            onnx_path, providers=["CPUExecutionProvider"], sess_options=opts
         )
-        self.session.intra_op_num_threads = 1
-        self.session.inter_op_num_threads = 1
 
         self._h = np.zeros((2, 1, 64)).astype("float32")
         self._c = np.zeros((2, 1, 64)).astype("float32")


### PR DESCRIPTION
`--vad silero` causes 100% cpu usage on 7 (out of 12) cores of my i7-1250U, which doesn't seem normal. I noticed that the threads configuration in [snakers4/silero-vad/blob/master/utils_vad.py](https://github.com/snakers4/silero-vad/blob/master/utils_vad.py) is different than in [vad.py](https://github.com/synesthesiam/homeassistant-satellite/blob/master/homeassistant_satellite/vad.py), so I copied it and the cpu usage dropped to almost zero! (without a noticeable drop in accuracy)