### PR TITLE
Pulseaudio support with ducking / echo-cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Enable [PulseAudio](https://www.freedesktop.org/wiki/Software/PulseAudio/) /
 [PipeWire](https://pipewire.org/) support with:
 
 ``` sh
-sudo apt instal install libpulse0
+sudo apt-get install libpulse0
 
 .venv/bin/pip3 install .[pulseaudio]
 ```

--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ Use`--volume-multiplier <VM>` to multiply volume by `<VM>` so 2.0 would be twice
 If your Home Assistant server uses https, you will need to add `--protocol https` to your command.
 
 
+### PulseAudio / PipeWire
+
+Use `--pulseaudio` to record and play audio aud PulseAudio or PipeWire. A socket
+or hostname can be provided as `--pulseaudio=<socket|host>`.
+
+When using PulseAudio, ducking and acoustic echo cancelation are available to
+facilitate cases when the satellite is simultaneously used to play music,
+movies, etc. Such sounds are captured by the microphone, together with the
+user's voice, and interfere wake word detection and speech recognition.
+
+`--echo-cancel` enables PulseAudio's acoustic echo cancelation, which removes
+playback sounds from the captured audio, making wake word detection easier.
+
+`--ducking=<vol>` sets the volume of all playback streams to `<vol>`
+(eg `0.2` for 20%) after the wake word is detected and until the pipeline
+finishes, making speech recognition easier.
+
+
 ## Running as a Service
 
 You can run homeassistant-satellite as a systemd service by first creating a service file:
@@ -174,6 +192,7 @@ Disable and stop the service with:
 ``` sh
 sudo systemctl disable --now homeassistant-satellite.service
 ```
+
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,17 @@ If your Home Assistant server uses https, you will need to add `--protocol https
 
 ### PulseAudio / PipeWire
 
-Use `--pulseaudio` to record and play audio aud PulseAudio or PipeWire. A socket
-or hostname can be provided as `--pulseaudio=<socket|host>`.
+Enable [PulseAudio](https://www.freedesktop.org/wiki/Software/PulseAudio/) /
+[PipeWire](https://pipewire.org/) support with:
+
+``` sh
+sudo apt instal install libpulse0
+
+.venv/bin/pip3 install .[pulseaudio]
+```
+
+Use `--pulseaudio` to record and play audio via PulseAudio or PipeWire. A socket
+or hostname can be optionally provided as `--pulseaudio=<socket|host>`.
 
 When using PulseAudio, ducking and acoustic echo cancelation are available to
 facilitate cases when the satellite is simultaneously used to play music,

--- a/homeassistant_satellite/__main__.py
+++ b/homeassistant_satellite/__main__.py
@@ -461,15 +461,14 @@ def _playback_proc(
 
         with play_ctx as (play, duck):
             for item in iter(playback_queue.get, None):
-                match item:
-                    case PlayMedia(media):
-                        play(media=media)
+                if isinstance(item, PlayMedia):
+                    play(item.media)
 
-                    case SetMicState(mic_state):
-                        state.mic = mic_state
+                elif isinstance(item, SetMicState):
+                    state.mic = item.mic_state
 
-                    case Duck(enable):
-                        duck(enable)
+                elif isinstance(item, Duck):
+                    duck(item.enable)
 
             return  # we got None from the queue, exit
 

--- a/homeassistant_satellite/__main__.py
+++ b/homeassistant_satellite/__main__.py
@@ -270,7 +270,7 @@ async def main() -> None:
                         # Start recording for next wake word (after TTS finishes)
                         playback_queue.put_nowait(SetMicState(MicState.WAIT_FOR_VAD))
 
-                        if event_type == "run-end" and args.ducking_volume is not None:
+                        if args.ducking_volume is not None:
                             playback_queue.put_nowait(Duck(False))
 
             except Exception:

--- a/homeassistant_satellite/__main__.py
+++ b/homeassistant_satellite/__main__.py
@@ -475,7 +475,7 @@ def _playback_proc(
 
     except Exception:
         _LOGGER.exception("Sound error in _playback_proc")
-        raise
+        os._exit(-1)
 
 
 # -----------------------------------------------------------------------------

--- a/homeassistant_satellite/mic.py
+++ b/homeassistant_satellite/mic.py
@@ -1,5 +1,4 @@
 import logging
-import socket
 import subprocess
 import time
 from typing import Final, Iterable, List, Tuple
@@ -24,6 +23,8 @@ def record_udp(
     samples_per_chunk: int = SAMPLES_PER_CHUNK,
 ) -> Iterable[Tuple[int, bytes]]:
     bytes_per_chunk = samples_per_chunk * WIDTH * CHANNELS
+
+    import socket  # only if needed
 
     udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     udp_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/homeassistant_satellite/mic.py
+++ b/homeassistant_satellite/mic.py
@@ -8,6 +8,8 @@ from .state import State
 DEFAULT_ARECORD: Final = "arecord -r 16000 -c 1 -f S16_LE -t raw"
 ARECORD_WITH_DEVICE: Final = "arecord -D {device} -r 16000 -c 1 -f S16_LE -t raw"
 
+APP_NAME: Final = "homeassistant_satellite"
+
 RATE: Final = 16000
 WIDTH: Final = 2
 CHANNELS: Final = 1
@@ -88,7 +90,7 @@ def record_pulseaudio(
         direction=pasimple.PA_STREAM_RECORD,
         server_name=server_name,
         device_name=device,
-        app_name="homeassistant_sattelite",
+        app_name=APP_NAME,
         format=pasimple.PA_SAMPLE_S16LE,
         channels=CHANNELS,
         rate=RATE,

--- a/homeassistant_satellite/snd.py
+++ b/homeassistant_satellite/snd.py
@@ -1,6 +1,8 @@
+import contextlib
 import logging
 import socket
 import subprocess
+from typing import Generator
 import wave
 from typing import Final, List
 
@@ -12,18 +14,57 @@ APLAY_WITH_DEVICE: Final = "aplay -D {device} -r {rate} -c 1 -f S16_LE -t raw"
 _LOGGER = logging.getLogger()
 
 
+@contextlib.contextmanager
 def play_udp(
-    media: str,
-    udp_socket: socket.socket,
     udp_port: int,
     state: State,
     sample_rate: int,
-    samples_per_chunk: int = 1024,
     volume: float = 1.0,
-) -> None:
+):
     """Uses ffmpeg to stream raw audio to a UDP port."""
     assert state.mic_host is not None
 
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as udp_socket:
+
+        def play(media: str):
+            with contextlib.closing(
+                media_to_chunks(media=media, sample_rate=sample_rate, volume=volume)
+            ) as chunks:
+                for chunk in chunks:
+                    udp_socket.sendto(chunk, (state.mic_host, udp_port))
+
+        yield play
+
+
+@contextlib.contextmanager
+def play_subprocess(
+    command: List[str],
+    sample_rate: int,
+    volume: float = 1.0,
+):
+    """Uses ffmpeg and a subprocess to play a URL to an audio output device."""
+    _LOGGER.debug("play: %s", command)
+
+    def play(media: str):
+        # Spawn a new subprocess each time we play a sound
+        with subprocess.Popen(
+            command, stdin=subprocess.PIPE
+        ) as snd_proc, contextlib.closing(
+            media_to_chunks(media=media, sample_rate=sample_rate, volume=volume)
+        ) as chunks:
+            assert snd_proc.stdin is not None
+            for chunk in chunks:
+                snd_proc.stdin.write(chunk)
+
+    yield play
+
+
+def media_to_chunks(
+    media: str,
+    sample_rate: int,
+    samples_per_chunk: int = 1024,
+    volume: float = 1.0,
+) -> Generator[bytes, None, None]:
     cmd = [
         "ffmpeg",
         "-i",
@@ -50,46 +91,5 @@ def play_udp(
             assert wav_file.getsampwidth() == 2
             chunk = wav_file.readframes(samples_per_chunk)
             while chunk:
-                udp_socket.sendto(chunk, (state.mic_host, udp_port))
-                chunk = wav_file.readframes(samples_per_chunk)
-
-
-def play_subprocess(
-    media: str,
-    command: List[str],
-    sample_rate: int,
-    samples_per_chunk: int = 1024,
-    volume: float = 1.0,
-) -> None:
-    """Uses ffmpeg and a subprocess to play a URL to an audio output device."""
-    ffmpeg_cmd = [
-        "ffmpeg",
-        "-i",
-        media,
-        "-f",
-        "wav",
-        "-ar",
-        str(sample_rate),
-        "-ac",
-        "1",
-        "-filter:a",
-        f"volume={volume}",
-        "-",
-    ]
-    _LOGGER.debug("play ffmpeg: %s", ffmpeg_cmd)
-    _LOGGER.debug("play: %s", command)
-
-    with subprocess.Popen(
-        ffmpeg_cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-    ) as ffmpeg_proc, subprocess.Popen(command, stdin=subprocess.PIPE) as snd_proc:
-        assert ffmpeg_proc.stdout is not None
-        assert snd_proc.stdin is not None
-
-        with wave.open(ffmpeg_proc.stdout, "rb") as wav_file:
-            assert wav_file.getsampwidth() == 2
-            chunk = wav_file.readframes(samples_per_chunk)
-            while chunk:
-                snd_proc.stdin.write(chunk)
+                yield chunk
                 chunk = wav_file.readframes(samples_per_chunk)

--- a/homeassistant_satellite/snd.py
+++ b/homeassistant_satellite/snd.py
@@ -13,6 +13,10 @@ APLAY_WITH_DEVICE: Final = "aplay -D {device} -r {rate} -c 1 -f S16_LE -t raw"
 _LOGGER = logging.getLogger()
 
 
+def duck_fail(enable: bool):
+    raise Exception("ducking not supported")
+
+
 @contextlib.contextmanager
 def play_udp(
     udp_port: int,
@@ -34,7 +38,7 @@ def play_udp(
                 for chunk in chunks:
                     udp_socket.sendto(chunk, (state.mic_host, udp_port))
 
-        yield play
+        yield play, duck_fail
 
 
 @contextlib.contextmanager
@@ -57,7 +61,76 @@ def play_subprocess(
             for chunk in chunks:
                 snd_proc.stdin.write(chunk)
 
-    yield play
+    yield play, duck_fail
+
+
+@contextlib.contextmanager
+def play_pulseaudio(
+    server: str,
+    device: str | None,
+    volume: float = 1.0,
+    ducking_volume: float = 0.2,
+):
+    """Uses ffmpeg and pulseaudio to play a URL to an audio output device."""
+
+    import pasimple  # only if
+    import pulsectl  # needed
+
+    sample_rate = 44100
+    server_name = server if server != "__default__" else None
+    app_name = "homeassistant_satellite"
+
+    with pasimple.PaSimple(
+        direction=pasimple.PA_STREAM_PLAYBACK,
+        server_name=server_name,
+        device_name=device,
+        app_name=app_name,
+        format=pasimple.PA_SAMPLE_S16LE,
+        channels=1,
+        rate=sample_rate,
+    ) as pa, pulsectl.Pulse(server=server_name) as pulse:
+        # find the sink we're using
+        if device:
+            sink = pulse.get_sink_by_name(device)
+        else:
+            server_info = pulse.server_info()
+            sink = pulse.get_sink_by_name(server_info.default_sink_name)
+
+        # set the volume of our own input stream
+        for input in pulse.sink_input_list():
+            if input.name == app_name:
+                pulse.volume_set_all_chans(input, volume)
+                break
+
+        orig_volume = {}  # remember original volume when ducking
+
+        def play(media: str):
+            with contextlib.closing(
+                media_to_chunks(
+                    media=media,
+                    sample_rate=sample_rate,
+                )
+            ) as chunks:
+                for chunk in chunks:
+                    pa.write(chunk)
+                pa.drain()
+
+        def duck(enable: bool):
+            for input in pulse.sink_input_list():
+                # we process all inputs of our sink, except our own input
+                if input.sink == sink.index and input.name != app_name:
+                    if enable:
+                        orig_volume[input.index] = pulsectl.PulseVolumeInfo(
+                            input.volume.values
+                        )
+                        pulse.volume_set_all_chans(input, ducking_volume)
+
+                    elif input.index in orig_volume:
+                        pulse.sink_input_volume_set(
+                            index=input.index, vol=orig_volume.pop(input.index)
+                        )
+
+        yield play, duck
 
 
 def media_to_chunks(

--- a/homeassistant_satellite/snd.py
+++ b/homeassistant_satellite/snd.py
@@ -73,8 +73,12 @@ def play_pulseaudio(
 ):
     """Uses ffmpeg and pulseaudio to play a URL to an audio output device."""
 
-    import pasimple  # only if
-    import pulsectl  # needed
+    try:
+        import pasimple
+        import pulsectl
+    except ImportError:
+        _LOGGER.fatal("Please pip install homeassistant_satellite[pulseaudio]")
+        raise
 
     sample_rate = 44100
     server_name = server if server != "__default__" else None

--- a/homeassistant_satellite/snd.py
+++ b/homeassistant_satellite/snd.py
@@ -1,6 +1,5 @@
 import contextlib
 import logging
-import socket
 import subprocess
 from typing import Generator
 import wave
@@ -23,6 +22,8 @@ def play_udp(
 ):
     """Uses ffmpeg to stream raw audio to a UDP port."""
     assert state.mic_host is not None
+
+    import socket  # only if needed
 
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as udp_socket:
 

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,3 +1,5 @@
 onnxruntime>=1.10.0,<2
 numpy<1.26
 webrtc-noise-gain==1.2.3
+pasimple>=0.0.2
+pulsectl>=23.5.2

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     extras_require={
         "silerovad": ["onnxruntime>=1.10.0,<2", "numpy<1.26"],
         "webrtc": ["webrtc-noise-gain==1.2.3"],
+        "pulseaudio": ["pasimple>=0.0.2", "pulsectl>=23.5.2"],
     },
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This PR adds pulseaudio/pipewire support as an optional dependency.

The killer feature: handling interfering music/movies/etc via ducking and echo-cancelation:

- `--echo-cancel` enables PulseAudio's acoustic echo cancelation, which removes playback sounds from the captured audio, making wake word detection easier.

  (The real work is done by pulseaudio, but it's useful to automatically setup the module so that the user doesn't have to mess with the pulseaudio config.)

- `--ducking=<vol>` sets the volume of all playback streams to `<vol>` (eg `0.2` for 20%) after the wake word is detected and until the pipeline finishes, making speech recognition easier.

Technical notes:
- There were already 2 audio backends, so adding a third was quite clean
- I turned the `play_*` methods into context managers, so that the stream setup happens there, making the `__main__` code cleaner.
- This PR includes the changes to have a separate playback thread (#1). I think avoiding blocking the main thread will be useful in the long run.
- Playback volume is handled natively by pulseaudio (ffmpeg not really needed, although I kept it to keep the code simpler).

