### PR TITLE
Create commandline entrypoint

### DIFF
--- a/homeassistant_satellite/__main__.py
+++ b/homeassistant_satellite/__main__.py
@@ -479,8 +479,14 @@ def _playback_proc(
 
 # -----------------------------------------------------------------------------
 
+
+def run():
+    asyncio.run(main())
+
+
+
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        main()
     except KeyboardInterrupt:
         pass

--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,9 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     keywords="voice satellite home assistant",
+    entry_points={
+        'console_scripts': [
+            'homeassistant-satellite = homeassistant_satellite:__main__.run'
+        ]
+    },
 )


### PR DESCRIPTION
When installing from pip dependencies will already be resolved, and you'll get a `homeassistant-satellite` executable in the PATH, which improves discoverability.

Similar to https://github.com/rhasspy/rhasspy3/pull/51