### PR TITLE
Keep HA connection open, fire HA events

### DIFF
--- a/homeassistant_satellite/ha_connection.py
+++ b/homeassistant_satellite/ha_connection.py
@@ -1,0 +1,145 @@
+from asyncio import Queue
+import asyncio
+import logging
+import os
+from typing import AsyncGenerator, Dict, List
+import aiohttp
+
+_LOGGER = logging.getLogger()
+
+
+class HAConnection:
+    """
+    Class handling all the low level websocket communication with HA.
+
+    Clients should only use the following high-level public functions for communicating with HA:
+
+        send_and_receive(message):       sends JSON message and returns the response
+
+        send_and_receive_many(message):  sends JSON message and returns generator of all responses
+
+        send_bytes(bytes):               sends binary message (without response)
+
+    Responses are properly dispatched to the corresponding message (based on
+    their message_id).  So the correct response will always be received, even if
+    messages arrive in different order.
+    """
+
+    def __init__(self, host: str, protocol: str, token: str, port: int = 8123):
+        self._token = token
+        self._message_id = 1
+
+        self._message_queues: Dict[int, Queue[dict]] = {}  # msg_id => queue of messages
+
+        ws_protocol = "wss" if protocol == "https" else "ws"
+        url = f"{ws_protocol}://{host}:{port}/api/websocket"
+
+        self._session = aiohttp.ClientSession()
+        self._websocket_context = self._session.ws_connect(url)
+
+    # Async context manager
+    async def __aenter__(self):
+        await self._session.__aenter__()
+        self.__websocket = await self._websocket_context.__aenter__()
+
+        await self.__authenticate()
+
+        # start the loop after authenticating
+        self.__receive_loop_task = asyncio.create_task(self.__receive_loop())
+
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.__receive_loop_task.cancel()
+
+        await self._websocket_context.__aexit__(exc_type, exc, tb)
+        await self._session.__aexit__(exc_type, exc, tb)
+
+    async def __receive_loop(self) -> None:
+        """Loop that receives and dispatches messages."""
+
+        try:
+            # Run until the task is cancelled
+            async for msg in self.__websocket:
+                if msg.type == aiohttp.WSMsgType.ERROR:
+                    _LOGGER.error("websocket connection error %s", msg)
+                    break
+                elif msg.type != aiohttp.WSMsgType.TEXT:
+                    _LOGGER.warning("unknown message type received: %s", msg.type)
+                    continue
+
+                # fulfill future, if available, otherwise queue the message
+                message = msg.json()
+                queue = self._message_queues.get(message["id"])
+                if queue is not None:
+                    await queue.put(message)
+                else:
+                    _LOGGER.warning(
+                        f"no consumer for received message_id {message['id']}"
+                    )
+
+            _LOGGER.error("websocket connection closed")
+
+            # we exit on every error, it's more robust to just restart than to try to recover
+            # TODO: more precise error handling
+            os._exit(-1)
+
+        except asyncio.CancelledError as e:
+            _LOGGER.debug("WS receive loop finished")
+
+    async def __authenticate(self) -> None:
+        """Authenticate websocket connection to HA"""
+
+        message = await self.__websocket.receive_json()
+        assert message["type"] == "auth_required", message
+
+        # raw send, no message id
+        await self.__websocket.send_json(
+            {
+                "type": "auth",
+                "access_token": self._token,
+            }
+        )
+
+        message = await self.__websocket.receive_json()
+        assert message.get("type") == "auth_ok", message
+        _LOGGER.info(
+            "Authenticated to Home Assistant version %s", message.get("ha_version")
+        )
+
+    ### Public functions to communicate with HA #############################33
+
+    async def send_and_receive(self, message: dict) -> dict:
+        """Send JSON message and receives the response"""
+
+        return await self.send_and_receive_many(message).__anext__()
+
+    async def send_and_receive_many(self, message: dict) -> AsyncGenerator[dict, None]:
+        """Send JSON message and receives all responses"""
+
+        assert isinstance(message, dict), "Invalid WS message type"
+
+        try:
+            message["id"] = self._message_id
+            self._message_id += 1
+
+            queue = Queue()
+            self._message_queues[message["id"]] = queue
+
+            _LOGGER.debug("send_json() message=%s", message)
+
+            await self.__websocket.send_json(message)
+
+            while True:
+                response = await queue.get()
+                _LOGGER.debug("send_and_subscribe_json() response=%s", response)
+                yield response
+
+        finally:
+            # delete the queue when the generator is closed
+            del self._message_queues[message["id"]]
+
+    async def send_bytes(self, bts: bytes):
+        """Send binary message (without response)"""
+
+        await self.__websocket.send_bytes(bts)

--- a/homeassistant_satellite/remote.py
+++ b/homeassistant_satellite/remote.py
@@ -1,84 +1,50 @@
 import asyncio
-import json
 import logging
 import time
 from typing import Any, AsyncGenerator, Dict, Optional, Tuple
 
-import aiohttp
+from .ha_connection import HAConnection
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def stream(
-    host: str,
-    protocol: str,
-    token: str,
+    ha_connection: HAConnection,
     audio: "asyncio.Queue[Tuple[int, bytes]]",
     pipeline_name: Optional[str] = None,
-    port: int = 8123,
-    api_path: str = "/api",
     audio_seconds_to_buffer: float = 0,
 ) -> AsyncGenerator[Tuple[int, str, Dict[str, Any]], None]:
     """Streams audio to an Assist pipeline and yields events as (timestamp, type, data)."""
-    ws_protocol = "wss" if protocol == "https" else "ws"
-    url = f"{ws_protocol}://{host}:{port}{api_path}/websocket"
-    message_id = 1
 
-    async with aiohttp.ClientSession() as session:
-        async with session.ws_connect(url) as websocket:
-            await _authenticate(websocket, token)
+    pipeline_id: Optional[str] = None
+    if pipeline_name:
+        pipeline_id = await _get_pipeline_id(ha_connection, pipeline_name)
 
-            pipeline_id: Optional[str] = None
-            if pipeline_name:
-                message_id, pipeline_id = await _get_pipeline_id(
-                    websocket, message_id, pipeline_name
-                )
-
-            message_id, handler_id = await _start_pipeline(
-                websocket,
-                message_id,
-                pipeline_id,
-                audio_seconds_to_buffer=audio_seconds_to_buffer,
-            )
-
-            async for timestamp, event_type, event_data in _audio_to_events(
-                websocket,
-                handler_id,
-                audio,
-            ):
-                yield timestamp, event_type, event_data
-
-
-async def _authenticate(websocket, token: str):
-    """Authenticates with HA using a long-lived access token."""
-    msg = await websocket.receive_json()
-    _LOGGER.debug(msg)
-    assert msg["type"] == "auth_required", msg
-    await websocket.send_json(
-        {
-            "type": "auth",
-            "access_token": token,
-        }
+    pipeline_events, handler_id = await _start_pipeline(
+        ha_connection,
+        pipeline_id,
+        audio_seconds_to_buffer=audio_seconds_to_buffer,
     )
 
-    msg = await websocket.receive_json()
-    _LOGGER.debug(msg)
-    assert msg["type"] == "auth_ok", msg
+    async for timestamp, event_type, event_data in _audio_to_events(
+        ha_connection,
+        pipeline_events,
+        handler_id,
+        audio,
+    ):
+        yield timestamp, event_type, event_data
 
 
 async def _get_pipeline_id(
-    websocket, message_id: int, pipeline_name: str
-) -> Tuple[int, Optional[str]]:
+    ha_connection: HAConnection, pipeline_name: str
+) -> Optional[str]:
     """Resolves pipeline id by name."""
-    await websocket.send_json(
+    msg = await ha_connection.send_and_receive(
         {
             "type": "assist_pipeline/pipeline/list",
-            "id": message_id,
         }
     )
-    msg = await websocket.receive_json()
     _LOGGER.debug(msg)
-    message_id += 1
 
     pipelines = msg["result"]["pipelines"]
     pipeline_id = _find_pipeline_by_name(
@@ -88,19 +54,17 @@ async def _get_pipeline_id(
     if not pipeline_id:
         _LOGGER.warning("No pipeline named %s in %s", pipeline_name, pipelines)
 
-    return message_id, pipeline_id
+    return pipeline_id
 
 
 async def _start_pipeline(
-    websocket,
-    message_id: int,
+    ha_connection,
     pipeline_id: Optional[str],
     audio_seconds_to_buffer: float = 0.0,
-) -> Tuple[int, int]:
+) -> Tuple[AsyncGenerator[dict, None], int]:
     """Starts Assist pipeline and returns (message id, handler id)"""
     pipeline_args = {
         "type": "assist_pipeline/run",
-        "id": message_id,
         "start_stage": "wake_word",
         "end_stage": "tts",
         "input": {
@@ -111,24 +75,26 @@ async def _start_pipeline(
     }
     if pipeline_id:
         pipeline_args["pipeline"] = pipeline_id
-    await websocket.send_json(pipeline_args)
-    message_id += 1
 
-    msg = await websocket.receive_json()
+    # send_and_receive_many returns a generator of all responses to our message
+    pipeline_events = ha_connection.send_and_receive_many(pipeline_args)
+
+    msg = await pipeline_events.__anext__()
     _LOGGER.debug(msg)
     assert msg["success"], "Pipeline failed to run"
 
     # Get handler id.
     # This is a single byte prefix that needs to be in every binary payload.
-    msg = await websocket.receive_json()
+    msg = await pipeline_events.__anext__()
     _LOGGER.debug(msg)
     handler_id = msg["event"]["data"]["runner_data"]["stt_binary_handler_id"]
 
-    return message_id, handler_id
+    return pipeline_events, handler_id
 
 
 async def _audio_to_events(
-    websocket,
+    ha_connection: HAConnection,
+    pipeline_events: AsyncGenerator[dict, None],
     handler_id: int,
     audio: "asyncio.Queue[Tuple[int, bytes]]",
 ) -> AsyncGenerator[Tuple[int, str, Dict[str, Any]], None]:
@@ -136,7 +102,7 @@ async def _audio_to_events(
     prefix_bytes = bytes([handler_id])
 
     audio_task = asyncio.create_task(audio.get())
-    event_task = asyncio.create_task(websocket.receive())
+    event_task = asyncio.ensure_future(pipeline_events.__anext__())
     pending = {audio_task, event_task}
 
     while True:
@@ -149,7 +115,9 @@ async def _audio_to_events(
             # Forward to websocket
             _timestamp, audio_chunk = audio_task.result()
             pending.add(
-                asyncio.create_task(websocket.send_bytes(prefix_bytes + audio_chunk))
+                asyncio.create_task(
+                    ha_connection.send_bytes(prefix_bytes + audio_chunk)
+                )
             )
 
             # Next audio chunk
@@ -157,15 +125,9 @@ async def _audio_to_events(
             pending.add(audio_task)
 
         if event_task in done:
-            msg = event_task.result()
-            if msg.type != aiohttp.WSMsgType.TEXT:
-                _LOGGER.warning("Unexpected message: %s", msg)
-                continue
+            event = event_task.result()
 
-            event = json.loads(msg.data)
-
-            if event.get("type") != "event":
-                continue
+            assert event["type"] == "event"
 
             _LOGGER.debug(event)
             event_type = event["event"]["type"]
@@ -183,7 +145,7 @@ async def _audio_to_events(
                 break
 
             # Next event
-            event_task = asyncio.create_task(websocket.receive())
+            event_task = asyncio.ensure_future(pipeline_events.__anext__())
             pending.add(event_task)
 
     for task in pending:

--- a/homeassistant_satellite/state.py
+++ b/homeassistant_satellite/state.py
@@ -14,3 +14,4 @@ class State:
     is_running: bool = True
     mic: MicState = MicState.NOT_RECORDING
     mic_host: Optional[str] = None
+    last_event: Optional[str] = None


### PR DESCRIPTION
In contrast to esphome satellites, there is no way to know from HA what homeassistant-satellite is doing, or control it. This PR is the first step in this direction.

- A `HAConnection` class is added handling all the "low-level" websocket communication with HA. It does proper dispatching based on `message_id` (no assumptions on the message order) and offers high-level functions to send messages and receive the corresponding response(s). This makes the rest of the code simpler and will certainly be useful as the satellite becomes more complex.

- The connection is kept open, not reopened for each pipeline (similarly to how esphome satellites stay connected). Apart from saving a bit of resources, this allows in the future to be able to communicate with the satellite at any moment, eg to enable/disable it.

- A first step towards controlling the satellite from HA: for the main pipeline events that affect the satellite's state, a HA event is fired to let the world know about our state. This allows, for instance, to create an "Assist in progress" template sensor, similar to that of esphome satellites.

Next step: enabling/disabling the satellite via a HA switch.

PS. I'm certainly open to different design decisions, just experimenting with the new tools.