### PR TITLE
Fix forcing webrtcvad by auto-gain/noise-suppression

### DIFF
--- a/homeassistant_satellite/__main__.py
+++ b/homeassistant_satellite/__main__.py
@@ -314,11 +314,8 @@ def _mic_proc(
         sub_chunk_bytes: Final = sub_chunk_samples * 2  # 16-bit
         wav_writer: Optional[wave.Wave_write] = None
 
-        if (
-            (args.vad == "webrtcvad")
-            or (args.noise_suppression > 0)
-            or (args.auto_gain > 0)
-        ):
+        webrtc_vad = args.vad == "webrtcvad"
+        if webrtc_vad or (args.noise_suppression > 0) or (args.auto_gain > 0):
             from webrtc_noise_gain import AudioProcessor
 
             audio_processor = AudioProcessor(args.auto_gain, args.noise_suppression)
@@ -367,7 +364,7 @@ def _mic_proc(
                     )
 
                     clean_chunk += result.audio
-                    if result.is_speech:
+                    if webrtc_vad and result.is_speech:
                         vad_prob = 1.0
 
                 # Overwrite with clean audio
@@ -379,7 +376,7 @@ def _mic_proc(
                     wav_writer.close()
                     wav_writer = None
 
-                if (vad is None) and (audio_processor is None):
+                if not (vad or webrtc_vad):
                     # No VAD
                     state.mic = MicState.RECORDING
                 else:


### PR DESCRIPTION
`--auto--gain` and `--noise-suppression` cause webrtcvad to be used, even under `--vad=disabled`. It's hard to spot cause [this code](https://github.com/synesthesiam/homeassistant-satellite/blob/3ac2445db7ec612282a130e4e0bccb9f138c7987/homeassistant_satellite/__main__.py#L235) thinks we don't use vad while [this code](https://github.com/synesthesiam/homeassistant-satellite/blob/3ac2445db7ec612282a130e4e0bccb9f138c7987/homeassistant_satellite/__main__.py#L382) thinks we do. The PR fixes this.

PS. Out of curiosity, is there a reason why webrtc-noise-gain [always enables vad](https://github.com/rhasspy/webrtc-noise-gain/blob/0b3bc23f5f33101df5b8f1970919500d8629b955/python.cpp#L50) instead of having it configurable? Doesn't it waste cpu?