### PR TITLE
(Possibly) local wake word detection via wyoming

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ Use`--auto-gain <AG>` to automatically increase the microphone volume (0-31 with
 
 Use`--volume-multiplier <VM>` to multiply volume by `<VM>` so 2.0 would be twice as loud (default: 1.0).
 
+### Wake word detection via a direct wyoming connection
+
+By default wake word detection is performed by forwarding audio to Home Assistant. It is also possible to perform wake word detection using a wyoming server,
+possibly (but not necessarily) running on the same machine as the satellite.
+
+To enable:
+``` sh
+.venv/bin/pip3 install .[wyoming]
+
+script/run ... --wake-word wyoming
+```
+
+Use `--wyoming-host <host>` to set the host of the wyoming server (default `localhost`).
+
+Use `--wyoming-port <port>` to set the port of the wyoming server (default `10400`).
+
+Use `--wake-word-id <id>` to detect a specific wake word instead of the server's default.
+
 ### HTTPS
 
 If your Home Assistant server uses https, you will need to add `--protocol https` to your command.

--- a/homeassistant_satellite/__main__.py
+++ b/homeassistant_satellite/__main__.py
@@ -21,6 +21,7 @@ from .mic_record import (
 )
 from .mic_process import (
     VAD_DISABLED,
+    WAKE_WORD_DISABLED,
     mic_thread_entry,
 )
 from .remote import stream
@@ -123,6 +124,15 @@ async def main() -> None:
     )
     parser.add_argument("--auto-gain", type=int, default=0, choices=list(range(32)))
     parser.add_argument("--volume-multiplier", type=float, default=1.0)
+    #
+    parser.add_argument(
+        "--wake-word",
+        choices=(WAKE_WORD_DISABLED, "wyoming"),
+        default=WAKE_WORD_DISABLED,
+    )
+    parser.add_argument("--wake-word-id", type=str)
+    parser.add_argument("--wyoming-host", type=str, default="localhost")
+    parser.add_argument("--wyoming-port", type=int, default=10400)
     #
     parser.add_argument(
         "--pulseaudio",
@@ -287,6 +297,7 @@ async def _run_pipeline(
         audio=recording_queue,
         pipeline_name=args.pipeline,
         audio_seconds_to_buffer=args.wake_buffer_seconds,
+        start_stage=("wake_word" if args.wake_word == WAKE_WORD_DISABLED else "stt"),
     ):
         _LOGGER.warning("%s %s", event_type, event_data)
 

--- a/homeassistant_satellite/__main__.py
+++ b/homeassistant_satellite/__main__.py
@@ -10,6 +10,7 @@ import sys
 import threading
 import time
 import wave
+import socket
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
@@ -323,6 +324,30 @@ async def _run_pipeline(
 
             if args.ducking_volume is not None:
                 playback_queue.put_nowait(Duck(False))
+
+        # For the main events that change the state of the satellite, fire a HA
+        # event to let the world know about our state. Skip consecutive same
+        # events (mainly consecutive run-ends).
+        if (
+            event_type in ["wake_word-end", "stt-end", "tts-end", "run-end"]
+            and event_type != state.last_event
+        ):
+            state.last_event = event_type
+            asyncio.create_task(  # in background
+                ha_connection.send_and_receive(
+                    {
+                        "type": "fire_event",
+                        "event_type": "homeassistant_satellite_event",
+                        "event_data": {
+                            "satellite_name": socket.gethostname(),
+                            "pipeline_event": {
+                                "type": event_type,
+                                "data": event_data,
+                            },
+                        },
+                    }
+                )
+            )
 
 
 # -----------------------------------------------------------------------------

--- a/homeassistant_satellite/__main__.py
+++ b/homeassistant_satellite/__main__.py
@@ -8,26 +8,20 @@ import shlex
 import shutil
 import sys
 import threading
-import time
-import wave
 import socket
-from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Deque, Final, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 from homeassistant_satellite.ha_connection import HAConnection
 
-from .mic import (
+from .mic_record import (
     ARECORD_WITH_DEVICE,
-    CHANNELS,
     DEFAULT_ARECORD,
-    RATE,
-    SAMPLES_PER_CHUNK,
-    WIDTH,
-    record_pulseaudio,
-    record_subprocess,
-    record_udp,
+)
+from .mic_process import (
+    VAD_DISABLED,
+    mic_thread_entry,
 )
 from .remote import stream
 from .snd import (
@@ -38,8 +32,6 @@ from .snd import (
     play_udp,
 )
 from .state import MicState, State
-from .util import multiply_volume
-from .vad import SileroVoiceActivityDetector, VoiceActivityDetector
 
 
 # items of the playback queue
@@ -60,7 +52,6 @@ class Duck:
 
 PlaybackQueueItem = Optional[Union[PlayMedia, SetMicState, Duck]]
 
-VAD_DISABLED = "disabled"
 _LOGGER = logging.getLogger(__name__)
 _DIR = Path(__file__).parent
 
@@ -220,20 +211,20 @@ async def main() -> None:
     loop = asyncio.get_running_loop()
     recording_queue: "asyncio.Queue[Tuple[int, bytes]]" = asyncio.Queue()
     playback_queue: "queue.Queue[PlaybackQueueItem]" = queue.Queue()
-    speech_detected = asyncio.Event()
+    ready_to_stream = asyncio.Event()
     state = State(mic=MicState.WAIT_FOR_VAD)
 
     # Recording thread for microphone
     mic_thread = threading.Thread(
-        target=_mic_proc,
-        args=(args, loop, recording_queue, speech_detected, state),
+        target=mic_thread_entry,
+        args=(args, loop, recording_queue, ready_to_stream, state),
         daemon=True,
     )
     mic_thread.start()
 
     # Playback thread
     playback_thread = threading.Thread(
-        target=_playback_proc,
+        target=_playback_thread_entry,
         args=(args, playback_queue, state),
         daemon=True,
     )
@@ -252,7 +243,7 @@ async def main() -> None:
                     args=args,
                     state=state,
                     ha_connection=ha_connection,
-                    speech_detected=speech_detected,
+                    ready_to_stream=ready_to_stream,
                     recording_queue=recording_queue,
                     playback_queue=playback_queue,
                 )
@@ -271,22 +262,25 @@ async def _run_pipeline(
     args,
     state: State,
     ha_connection: HAConnection,
-    speech_detected: asyncio.Event,
+    ready_to_stream: asyncio.Event,
     recording_queue: "asyncio.Queue[Tuple[int, bytes]]",
     playback_queue: "queue.Queue[PlaybackQueueItem]",
 ):
     """Run a single pipeline in the main thread"""
 
+    state.pipeline_count += 1
+
     if args.vad != VAD_DISABLED:
         _LOGGER.debug("Waiting for speech")
-        await speech_detected.wait()
-        speech_detected.clear()
+
+    # The ready_to_stream event fires when local processing is over and we are
+    # ready to stream audio to HA.
+    await ready_to_stream.wait()
+    ready_to_stream.clear()
 
     if not state.is_running:
         # Error in mic thread
         return
-
-    _LOGGER.warning("Speech detected")
 
     async for _timestamp, event_type, event_data in stream(
         ha_connection=ha_connection,
@@ -353,148 +347,7 @@ async def _run_pipeline(
 # -----------------------------------------------------------------------------
 
 
-def _mic_proc(
-    args: argparse.Namespace,
-    loop: asyncio.AbstractEventLoop,
-    audio_queue: "asyncio.Queue[Tuple[int, bytes]]",
-    speech_detected: asyncio.Event,
-    state: State,
-) -> None:
-    try:
-        audio_processor: "Optional[AudioProcessor]" = None
-        vad: Optional[VoiceActivityDetector] = None
-        vad_activation: int = 0
-        vad_chunk_buffer: Deque[Tuple[int, bytes]] = deque(
-            maxlen=args.vad_buffer_chunks
-        )
-        sub_chunk_samples: Final = 160
-        sub_chunk_bytes: Final = sub_chunk_samples * 2  # 16-bit
-        wav_writer: Optional[wave.Wave_write] = None
-
-        if (
-            (args.vad == "webrtcvad")
-            or (args.noise_suppression > 0)
-            or (args.auto_gain > 0)
-        ):
-            from webrtc_noise_gain import AudioProcessor
-
-            audio_processor = AudioProcessor(args.auto_gain, args.noise_suppression)
-
-            # Required so we don't need an extra buffer
-            assert (
-                SAMPLES_PER_CHUNK % sub_chunk_samples
-            ) == 0, "Audio chunks must be a multiple of 10ms"
-            _LOGGER.debug("Using webrtc audio processing")
-
-        if args.vad == "silero":
-            vad = SileroVoiceActivityDetector(args.vad_model)
-            _LOGGER.debug("Using silero VAD")
-
-        if args.udp_mic is not None:
-            # UDP socket
-            mic_stream = record_udp(args.udp_mic, state)
-        elif args.pulseaudio is not None:
-            # PulseAudio
-            mic_stream = record_pulseaudio(args.pulseaudio, args.mic_device)
-        else:
-            # External program
-            mic_stream = record_subprocess(args.mic_command)
-
-        for ts_chunk in mic_stream:
-            if not state.is_running:
-                break
-
-            timestamp, chunk = ts_chunk
-            vad_prob = 0.0
-
-            if args.volume_multiplier != 1.0:
-                chunk = multiply_volume(chunk, args.volume_multiplier)
-
-            # Process in 10ms sub-chunks.
-            if audio_processor is not None:
-                clean_chunk = bytes()
-                ap_sub_chunks = len(chunk) // sub_chunk_bytes
-                if (len(chunk) % sub_chunk_bytes) != 0:
-                    _LOGGER.warning("Mic chunk size is not a multiple of 10ms")
-
-                for sub_chunk_idx in range(ap_sub_chunks):
-                    sub_chunk_offset = sub_chunk_idx * sub_chunk_bytes
-                    result = audio_processor.Process10ms(
-                        chunk[sub_chunk_offset : (sub_chunk_offset + sub_chunk_bytes)]
-                    )
-
-                    clean_chunk += result.audio
-                    if result.is_speech:
-                        vad_prob = 1.0
-
-                # Overwrite with clean audio
-                chunk = clean_chunk
-                ts_chunk = (timestamp, clean_chunk)
-
-            if state.mic == MicState.WAIT_FOR_VAD:
-                if wav_writer is not None:
-                    wav_writer.close()
-                    wav_writer = None
-
-                if (vad is None) and (audio_processor is None):
-                    # No VAD
-                    state.mic = MicState.RECORDING
-                else:
-                    if vad is not None:
-                        # silero
-                        vad_prob = vad(chunk)
-
-                    if vad_prob >= args.vad_threshold:
-                        vad_activation += 1
-                    else:
-                        vad_activation = max(0, vad_activation - 1)
-
-                    if vad_activation >= args.vad_trigger_level:
-                        state.mic = MicState.RECORDING
-                        speech_detected.set()
-
-                        if vad is not None:
-                            vad.reset()
-
-                        vad_activation = 0
-                    else:
-                        vad_chunk_buffer.append(ts_chunk)
-
-            if state.mic == MicState.RECORDING:
-                if args.debug_recording_dir and (wav_writer is None):
-                    # Save audio
-                    wav_writer = wave.open(
-                        str(args.debug_recording_dir / f"{time.monotonic_ns()}.wav"),
-                        "wb",
-                    )
-                    wav_writer.setframerate(RATE)
-                    wav_writer.setsampwidth(WIDTH)
-                    wav_writer.setnchannels(CHANNELS)
-
-                if vad_chunk_buffer:
-                    for buffered_chunk in vad_chunk_buffer:
-                        loop.call_soon_threadsafe(
-                            audio_queue.put_nowait, buffered_chunk
-                        )
-
-                        if wav_writer is not None:
-                            wav_writer.writeframes(buffered_chunk[1])
-
-                    vad_chunk_buffer.clear()
-
-                loop.call_soon_threadsafe(audio_queue.put_nowait, ts_chunk)
-                if wav_writer is not None:
-                    wav_writer.writeframes(ts_chunk[1])
-
-    except Exception:
-        _LOGGER.exception("Unexpected error in _mic_proc")
-        os._exit(-1)  # pylint: disable=protected-access
-
-
-# ----------------------------
-
-
-def _playback_proc(
+def _playback_thread_entry(
     args: argparse.Namespace,
     playback_queue: "queue.Queue[PlaybackQueueItem]",
     state: State,
@@ -547,7 +400,7 @@ def _playback_proc(
             return  # we got None from the queue, exit
 
     except Exception:
-        _LOGGER.exception("Sound error in _playback_proc")
+        _LOGGER.exception("Sound error in _playback_thread_entry")
         os._exit(-1)  # pylint: disable=protected-access
 
 

--- a/homeassistant_satellite/__main__.py
+++ b/homeassistant_satellite/__main__.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Deque, Final, Optional, Tuple, Union
 
+from homeassistant_satellite.ha_connection import HAConnection
+
 from .mic import (
     ARECORD_WITH_DEVICE,
     CHANNELS,
@@ -236,69 +238,91 @@ async def main() -> None:
     )
     playback_thread.start()
 
-    # Send requests to the playback thread
+    # Connect to HA and continuously run pipelines
     try:
-        while state.is_running:
-            try:
-                if args.vad != VAD_DISABLED:
-                    _LOGGER.debug("Waiting for speech")
-                    await speech_detected.wait()
-                    speech_detected.clear()
+        async with HAConnection(
+            host=args.host,
+            protocol=args.protocol,
+            port=args.port,
+            token=token,
+        ) as ha_connection:
+            while state.is_running:
+                await _run_pipeline(
+                    args=args,
+                    state=state,
+                    ha_connection=ha_connection,
+                    speech_detected=speech_detected,
+                    recording_queue=recording_queue,
+                    playback_queue=playback_queue,
+                )
 
-                    if not state.is_running:
-                        # Error in mic thread
-                        break
+    except Exception:
+        _LOGGER.exception("Unknown exception in the main thread")
 
-                    _LOGGER.debug("Speech detected")
-
-                async for _timestamp, event_type, event_data in stream(
-                    host=args.host,
-                    protocol=args.protocol,
-                    port=args.port,
-                    token=token,
-                    audio=recording_queue,
-                    pipeline_name=args.pipeline,
-                    audio_seconds_to_buffer=args.wake_buffer_seconds,
-                ):
-                    _LOGGER.debug("%s %s", event_type, event_data)
-
-                    if event_type == "wake_word-end":
-                        if args.ducking_volume is not None:
-                            playback_queue.put_nowait(Duck(True))
-
-                        if args.awake_sound:
-                            state.mic = MicState.NOT_RECORDING
-                            playback_queue.put_nowait(PlayMedia(args.awake_sound))
-                            playback_queue.put_nowait(SetMicState(MicState.RECORDING))
-
-                    elif event_type == "stt-end":
-                        # Stop recording until run ends
-                        state.mic = MicState.NOT_RECORDING
-                        if args.done_sound:
-                            playback_queue.put_nowait(PlayMedia(args.done_sound))
-
-                    elif event_type == "tts-end":
-                        # Play TTS output
-                        tts_url = event_data.get("tts_output", {}).get("url")
-                        if tts_url:
-                            url = f"{args.protocol}://{args.host}:{args.port}{tts_url}"
-                            playback_queue.put_nowait(PlayMedia(url))
-
-                    elif event_type in ("run-end", "error"):
-                        # Start recording for next wake word (after TTS finishes)
-                        playback_queue.put_nowait(SetMicState(MicState.WAIT_FOR_VAD))
-
-                        if args.ducking_volume is not None:
-                            playback_queue.put_nowait(Duck(False))
-
-            except Exception:
-                _LOGGER.exception("Unexpected error")
-                state.mic = MicState.WAIT_FOR_VAD
     finally:
         state.is_running = False
         mic_thread.join()
         playback_queue.put_nowait(None)  # exit request
         playback_thread.join()
+
+
+async def _run_pipeline(
+    args,
+    state: State,
+    ha_connection: HAConnection,
+    speech_detected: asyncio.Event,
+    recording_queue: "asyncio.Queue[Tuple[int, bytes]]",
+    playback_queue: "queue.Queue[PlaybackQueueItem]",
+):
+    """Run a single pipeline in the main thread"""
+
+    if args.vad != VAD_DISABLED:
+        _LOGGER.debug("Waiting for speech")
+        await speech_detected.wait()
+        speech_detected.clear()
+
+    if not state.is_running:
+        # Error in mic thread
+        return
+
+    _LOGGER.warning("Speech detected")
+
+    async for _timestamp, event_type, event_data in stream(
+        ha_connection=ha_connection,
+        audio=recording_queue,
+        pipeline_name=args.pipeline,
+        audio_seconds_to_buffer=args.wake_buffer_seconds,
+    ):
+        _LOGGER.warning("%s %s", event_type, event_data)
+
+        if event_type == "wake_word-end":
+            if args.ducking_volume is not None:
+                playback_queue.put_nowait(Duck(True))
+
+            if args.awake_sound:
+                state.mic = MicState.NOT_RECORDING
+                playback_queue.put_nowait(PlayMedia(args.awake_sound))
+                playback_queue.put_nowait(SetMicState(MicState.RECORDING))
+
+        elif event_type == "stt-end":
+            # Stop recording until run ends
+            state.mic = MicState.NOT_RECORDING
+            if args.done_sound:
+                playback_queue.put_nowait(PlayMedia(args.done_sound))
+
+        elif event_type == "tts-end":
+            # Play TTS output
+            tts_url = event_data.get("tts_output", {}).get("url")
+            if tts_url:
+                url = f"{args.protocol}://{args.host}:{args.port}{tts_url}"
+                playback_queue.put_nowait(PlayMedia(url))
+
+        elif event_type in ("run-end", "error"):
+            # Start recording for next wake word (after TTS finishes)
+            playback_queue.put_nowait(SetMicState(MicState.WAIT_FOR_VAD))
+
+            if args.ducking_volume is not None:
+                playback_queue.put_nowait(Duck(False))
 
 
 # -----------------------------------------------------------------------------

--- a/homeassistant_satellite/ha_connection.py
+++ b/homeassistant_satellite/ha_connection.py
@@ -1,0 +1,145 @@
+from asyncio import Queue
+import asyncio
+import logging
+import os
+from typing import AsyncGenerator, Dict, List
+import aiohttp
+
+_LOGGER = logging.getLogger()
+
+
+class HAConnection:
+    """
+    Class handling all the low level websocket communication with HA.
+
+    Clients should only use the following high-level public functions for communicating with HA:
+
+        send_and_receive(message):       sends JSON message and returns the response
+
+        send_and_receive_many(message):  sends JSON message and returns generator of all responses
+
+        send_bytes(bytes):               sends binary message (without response)
+
+    Responses are properly dispatched to the corresponding message (based on
+    their message_id).  So the correct response will always be received, even if
+    messages arrive in different order.
+    """
+
+    def __init__(self, host: str, protocol: str, token: str, port: int = 8123):
+        self._token = token
+        self._message_id = 1
+
+        self._message_queues: Dict[int, Queue[dict]] = {}  # msg_id => queue of messages
+
+        ws_protocol = "wss" if protocol == "https" else "ws"
+        url = f"{ws_protocol}://{host}:{port}/api/websocket"
+
+        self._session = aiohttp.ClientSession()
+        self._websocket_context = self._session.ws_connect(url)
+
+    # Async context manager
+    async def __aenter__(self):
+        await self._session.__aenter__()
+        self.__websocket = await self._websocket_context.__aenter__()
+
+        await self.__authenticate()
+
+        # start the loop after authenticating
+        self.__receive_loop_task = asyncio.create_task(self.__receive_loop())
+
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.__receive_loop_task.cancel()
+
+        await self._websocket_context.__aexit__(exc_type, exc, tb)
+        await self._session.__aexit__(exc_type, exc, tb)
+
+    async def __receive_loop(self) -> None:
+        """Loop that receives and dispatches messages."""
+
+        try:
+            # Run until the task is cancelled
+            async for msg in self.__websocket:
+                if msg.type == aiohttp.WSMsgType.ERROR:
+                    _LOGGER.error("websocket connection error %s", msg)
+                    break
+                elif msg.type != aiohttp.WSMsgType.TEXT:
+                    _LOGGER.warning("unknown message type received: %s", msg.type)
+                    continue
+
+                # fulfill future, if available, otherwise queue the message
+                message = msg.json()
+                queue = self._message_queues.get(message["id"])
+                if queue is not None:
+                    await queue.put(message)
+                else:
+                    _LOGGER.warning(
+                        f"no consumer for received message_id {message['id']}"
+                    )
+
+            _LOGGER.error("websocket connection closed")
+
+            # we exit on every error, it's more robust to just restart than to try to recover
+            # TODO: more precise error handling
+            os._exit(-1)
+
+        except asyncio.CancelledError as e:
+            _LOGGER.debug("WS receive loop finished")
+
+    async def __authenticate(self) -> None:
+        """Authenticate websocket connection to HA"""
+
+        message = await self.__websocket.receive_json()
+        assert message["type"] == "auth_required", message
+
+        # raw send, no message id
+        await self.__websocket.send_json(
+            {
+                "type": "auth",
+                "access_token": self._token,
+            }
+        )
+
+        message = await self.__websocket.receive_json()
+        assert message.get("type") == "auth_ok", message
+        _LOGGER.info(
+            "Authenticated to Home Assistant version %s", message.get("ha_version")
+        )
+
+    ### Public functions to communicate with HA #############################33
+
+    async def send_and_receive(self, message: dict) -> dict:
+        """Send JSON message and receives the response"""
+
+        return await self.send_and_receive_many(message).__anext__()
+
+    async def send_and_receive_many(self, message: dict) -> AsyncGenerator[dict, None]:
+        """Send JSON message and receives all responses"""
+
+        assert isinstance(message, dict), "Invalid WS message type"
+
+        try:
+            message["id"] = self._message_id
+            self._message_id += 1
+
+            queue = Queue()
+            self._message_queues[message["id"]] = queue
+
+            _LOGGER.debug("send_json() message=%s", message)
+
+            await self.__websocket.send_json(message)
+
+            while True:
+                response = await queue.get()
+                _LOGGER.debug("send_and_subscribe_json() response=%s", response)
+                yield response
+
+        finally:
+            # delete the queue when the generator is closed
+            del self._message_queues[message["id"]]
+
+    async def send_bytes(self, bts: bytes):
+        """Send binary message (without response)"""
+
+        await self.__websocket.send_bytes(bts)

--- a/homeassistant_satellite/mic_process.py
+++ b/homeassistant_satellite/mic_process.py
@@ -1,0 +1,319 @@
+"""
+This module runs in the mic thread and is responsible for processing the chunks
+recorded from the microphone.
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+from pathlib import Path
+import time
+import wave
+from collections import deque
+from typing import Deque, Final, Optional, Tuple
+
+from .mic_record import (
+    CHANNELS,
+    RATE,
+    SAMPLES_PER_CHUNK,
+    WIDTH,
+    MicStream,
+    record_pulseaudio,
+    record_subprocess,
+    record_udp,
+)
+from .state import MicState, State
+from .util import multiply_volume
+from .vad import SileroVoiceActivityDetector
+
+VAD_DISABLED = "disabled"
+
+_LOGGER = logging.getLogger()
+
+
+"""
+Mic processing is performed by "piping" several functions that perform
+independent work. Each receives a MicStream (ts_chunk iterable) as input and
+produces a MicStream in the ouput. Each pipe is allowed to modify chunks, block
+them, buffer them, etc. Chunks that exit the whole pipeline are streamed to HA.
+"""
+
+
+def __ensure_running_pipe(
+    input: MicStream,
+    state: State,
+) -> MicStream:
+    """Stops the recording pipeline when exiting."""
+
+    for ts_chunk in input:
+        if not state.is_running:
+            break
+
+        yield ts_chunk
+
+
+def _volume_multiplier_pipe(
+    input: MicStream,
+    volume_multiplier: float,
+) -> MicStream:
+    """Multiplies the volume of all passing chunks."""
+
+    for timestamp, chunk in input:
+        chunk = multiply_volume(chunk, volume_multiplier)
+        yield timestamp, chunk
+
+
+def _webrtc_pipe(
+    input: MicStream,
+    state: State,
+    noise_suppression: int,
+    auto_gain: int,
+    vad_enabled: bool,
+) -> MicStream:
+    """
+    Processes passing chunks with webrtc. If vad_enabled == True it also
+    performs VAD for each chunk and stores the result in state.vad_prob.
+    """
+
+    from webrtc_noise_gain import AudioProcessor
+
+    audio_processor = AudioProcessor(auto_gain, noise_suppression)
+
+    sub_chunk_samples: Final = 160
+    sub_chunk_bytes: Final = sub_chunk_samples * 2  # 16-bit
+
+    # Required so we don't need an extra buffer
+    assert (
+        SAMPLES_PER_CHUNK % sub_chunk_samples
+    ) == 0, "Audio chunks must be a multiple of 10ms"
+    _LOGGER.debug("Using webrtc audio processing")
+
+    for timestamp, chunk in input:
+        clean_chunk = bytes()
+        ap_sub_chunks = len(chunk) // sub_chunk_bytes
+        if (len(chunk) % sub_chunk_bytes) != 0:
+            _LOGGER.warning("Mic chunk size is not a multiple of 10ms")
+
+        for sub_chunk_idx in range(ap_sub_chunks):
+            sub_chunk_offset = sub_chunk_idx * sub_chunk_bytes
+            result = audio_processor.Process10ms(
+                chunk[sub_chunk_offset : (sub_chunk_offset + sub_chunk_bytes)]
+            )
+
+            clean_chunk += result.audio
+
+            if vad_enabled and state.mic == MicState.WAIT_FOR_VAD and result.is_speech:
+                state.vad_prob = 1.0
+
+        # return clean audio
+        yield timestamp, clean_chunk
+
+
+def _silero_pipe(
+    input: MicStream,
+    vad_model: str,
+    state: State,
+) -> MicStream:
+    """Performs silero VAD for each passing chunk and stores the result in state.vad_prob."""
+
+    _LOGGER.debug("Using silero VAD")
+
+    silero = SileroVoiceActivityDetector(vad_model)
+    running = False
+
+    for timestamp, chunk in input:
+        if state.mic == MicState.WAIT_FOR_VAD:
+            running = True
+            state.vad_prob = silero(chunk)
+
+        elif running:
+            running = False
+            silero.reset()
+
+        yield timestamp, chunk
+
+
+def _vad_pipe(
+    input: MicStream,
+    vad_threshold: float,
+    vad_trigger_level: int,
+    vad_buffer_chunks: int,
+    event: asyncio.Event,
+    state: State,
+) -> MicStream:
+    """
+    Implements VAD logic. During WAIT_FOR_VAD we block and buffer chunks until
+    the VAD trigger is reached. For this to work VAD evaluation must have been
+    already performed in the input chunks (by _webrtc_pipe and _silero_pipe),
+    the result is read from state.vad_prob.
+
+    After triggering, previously buffered chunks as well as all future chunks
+    are sent to the output.
+    """
+
+    vad_activation: int = 0
+    vad_chunk_buffer: Deque[Tuple[int, bytes]] = deque(maxlen=vad_buffer_chunks)
+
+    for ts_chunk in input:
+        # If we're not waiting for VAD, just let the chunk pass through
+        if state.mic != MicState.WAIT_FOR_VAD:
+            yield ts_chunk
+            continue
+
+        # We're waiting for VAD, chunks are buffered until we trigger
+        vad_chunk_buffer.append(ts_chunk)
+
+        # count activations based on the state.vad_prob already set upstream
+        if state.vad_prob >= vad_threshold:
+            vad_activation += 1
+        else:
+            vad_activation = max(0, vad_activation - 1)
+        state.vad_prob = 0
+
+        if vad_activation >= vad_trigger_level:
+            # Waiting for VAD and just got triggered, set the state and send
+            # buffered chunks downstream before continuing with new ones
+            _LOGGER.warning("Speech detected")
+
+            state.mic = MicState.RECORDING
+            event.set()
+
+            for buffered_chunk in vad_chunk_buffer:
+                yield buffered_chunk
+
+            vad_activation = 0
+            vad_chunk_buffer.clear()
+
+
+def _skip_mic_state_pipe(
+    input: MicStream,
+    state: State,
+    skip: MicState,
+    event: asyncio.Event | None = None,
+):
+    """Skips one MicState of the processing pipeline and continuous immediately to the next one.
+    If event is not None it is set when the skip occurs.
+    """
+
+    for ts_chunk in input:
+        if state.mic == skip:
+            state.mic = state.mic.next()
+
+            if event is not None:
+                event.set()
+
+        yield ts_chunk
+
+def _wav_writer_pipe(
+    input: MicStream,
+    state: State,
+    debug_recording_dir: Path,
+) -> MicStream:
+    """Record the chunks passing through us in a wav file."""
+
+    wav_writer: Optional[wave.Wave_write] = None
+    current_pipeline = -1
+
+    for timestamp, chunk in input:
+        # wav_writer is installed after VAD so all the chunks we see are meant to be recorded.
+        # Note that the state might go from RECORDING to RECORDING again in the next pipeline, so
+        # we detect that the pipeline changed from state.pipeline_count.
+
+        if current_pipeline != state.pipeline_count:
+            if wav_writer is not None:
+                wav_writer.close()
+
+            wav_writer = wave.open(
+                str(debug_recording_dir / f"{time.monotonic_ns()}.wav"),
+                "wb",
+            )
+            wav_writer.setframerate(RATE)
+            wav_writer.setsampwidth(WIDTH)
+            wav_writer.setnchannels(CHANNELS)
+
+        assert wav_writer
+        wav_writer.writeframes(chunk)
+
+        yield timestamp, chunk
+
+
+def mic_thread_entry(
+    args: argparse.Namespace,
+    loop: asyncio.AbstractEventLoop,
+    recording_queue: "asyncio.Queue[Tuple[int, bytes]]",
+    ready_to_stream: asyncio.Event,
+    state: State,
+) -> None:
+    """
+    The entrypoint of the mic thread. Reads chunks from the microphone, pipes them through
+    various processing stages and finally outputs them to the recording_queue.
+    """
+
+    try:
+        # Select our mic source
+        if args.udp_mic is not None:
+            mic_stream = record_udp(args.udp_mic, state)
+        elif args.pulseaudio is not None:
+            mic_stream = record_pulseaudio(args.pulseaudio, args.mic_device)
+        else:
+            mic_stream = record_subprocess(args.mic_command)
+
+        # Then, depending on the given arguments, enable the corresponding pipes
+        # to process the mic audio.
+
+        mic_stream = __ensure_running_pipe(input=mic_stream, state=state)
+
+        if args.volume_multiplier != 1.0:
+            mic_stream = _volume_multiplier_pipe(
+                input=mic_stream, volume_multiplier=args.volume_multiplier
+            )
+
+        if args.vad == "webrtcvad" or args.noise_suppression > 0 or args.auto_gain > 0:
+            mic_stream = _webrtc_pipe(
+                input=mic_stream,
+                state=state,
+                noise_suppression=args.noise_suppression,
+                auto_gain=args.auto_gain,
+                vad_enabled=(args.vad == "webrtcvad"),
+            )
+
+        if args.vad == "silero":
+            mic_stream = _silero_pipe(
+                input=mic_stream,
+                state=state,
+                vad_model=args.vad_model,
+            )
+
+        if args.vad != VAD_DISABLED:
+            mic_stream = _vad_pipe(
+                input=mic_stream,
+                state=state,
+                vad_threshold=args.vad_threshold,
+                vad_trigger_level=args.vad_trigger_level,
+                vad_buffer_chunks=args.vad_buffer_chunks,
+                event=ready_to_stream,
+            )
+        else:
+            # No vad, skip it
+            mic_stream = _skip_mic_state_pipe(
+                input=mic_stream,
+                state=state,
+                skip=MicState.WAIT_FOR_VAD,
+            )
+
+
+        if args.debug_recording_dir:
+            mic_stream = _wav_writer_pipe(
+                input=mic_stream,
+                state=state,
+                debug_recording_dir=args.debug_recording_dir,
+            )
+
+        # Finally, the chunks passing through all pipes are ready to be streamed
+        for ts_chunk in mic_stream:
+            loop.call_soon_threadsafe(recording_queue.put_nowait, ts_chunk)
+
+    except Exception:
+        _LOGGER.exception("Unexpected error in mic_thread_entry")
+        os._exit(-1)  # pylint: disable=protected-access

--- a/homeassistant_satellite/mic_record.py
+++ b/homeassistant_satellite/mic_record.py
@@ -17,13 +17,15 @@ SAMPLES_PER_CHUNK = int(0.03 * RATE)  # 30ms
 
 _LOGGER = logging.getLogger()
 
+MicStream = Iterable[Tuple[int, bytes]]
+
 
 def record_udp(
     port: int,
     state: State,
     host: str = "0.0.0.0",
     samples_per_chunk: int = SAMPLES_PER_CHUNK,
-) -> Iterable[Tuple[int, bytes]]:
+) -> MicStream:
     bytes_per_chunk = samples_per_chunk * WIDTH * CHANNELS
 
     import socket  # only if needed
@@ -61,7 +63,7 @@ def record_udp(
 def record_subprocess(
     command: List[str],
     samples_per_chunk: int = SAMPLES_PER_CHUNK,
-) -> Iterable[Tuple[int, bytes]]:
+) -> MicStream:
     """Yield mic samples from a subprocess with a timestamp."""
     _LOGGER.debug("Microphone command: %s", command)
     bytes_per_chunk = samples_per_chunk * WIDTH * CHANNELS
@@ -79,7 +81,7 @@ def record_pulseaudio(
     server: str,
     device: Optional[str],
     samples_per_chunk: int = SAMPLES_PER_CHUNK,
-) -> Iterable[Tuple[int, bytes]]:
+) -> MicStream:
     """Yield mic samples with a timestamp."""
 
     import pasimple  # only if needed

--- a/homeassistant_satellite/remote.py
+++ b/homeassistant_satellite/remote.py
@@ -1,84 +1,50 @@
 import asyncio
-import json
 import logging
 import time
 from typing import Any, AsyncGenerator, Dict, Optional, Tuple
 
-import aiohttp
+from .ha_connection import HAConnection
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def stream(
-    host: str,
-    protocol: str,
-    token: str,
+    ha_connection: HAConnection,
     audio: "asyncio.Queue[Tuple[int, bytes]]",
     pipeline_name: Optional[str] = None,
-    port: int = 8123,
-    api_path: str = "/api",
     audio_seconds_to_buffer: float = 0,
 ) -> AsyncGenerator[Tuple[int, str, Dict[str, Any]], None]:
     """Streams audio to an Assist pipeline and yields events as (timestamp, type, data)."""
-    ws_protocol = "wss" if protocol == "https" else "ws"
-    url = f"{ws_protocol}://{host}:{port}{api_path}/websocket"
-    message_id = 1
 
-    async with aiohttp.ClientSession() as session:
-        async with session.ws_connect(url) as websocket:
-            await _authenticate(websocket, token)
+    pipeline_id: Optional[str] = None
+    if pipeline_name:
+        pipeline_id = await _get_pipeline_id(ha_connection, pipeline_name)
 
-            pipeline_id: Optional[str] = None
-            if pipeline_name:
-                message_id, pipeline_id = await _get_pipeline_id(
-                    websocket, message_id, pipeline_name
-                )
-
-            message_id, handler_id = await _start_pipeline(
-                websocket,
-                message_id,
-                pipeline_id,
-                audio_seconds_to_buffer=audio_seconds_to_buffer,
-            )
-
-            async for timestamp, event_type, event_data in _audio_to_events(
-                websocket,
-                handler_id,
-                audio,
-            ):
-                yield timestamp, event_type, event_data
-
-
-async def _authenticate(websocket, token: str):
-    """Authenticates with HA using a long-lived access token."""
-    msg = await websocket.receive_json()
-    _LOGGER.debug(msg)
-    assert msg["type"] == "auth_required", msg
-    await websocket.send_json(
-        {
-            "type": "auth",
-            "access_token": token,
-        }
+    pipeline_events, handler_id = await _start_pipeline(
+        ha_connection,
+        pipeline_id,
+        audio_seconds_to_buffer=audio_seconds_to_buffer,
     )
 
-    msg = await websocket.receive_json()
-    _LOGGER.debug(msg)
-    assert msg["type"] == "auth_ok", msg
+    async for timestamp, event_type, event_data in _audio_to_events(
+        ha_connection,
+        pipeline_events,
+        handler_id,
+        audio,
+    ):
+        yield timestamp, event_type, event_data
 
 
 async def _get_pipeline_id(
-    websocket, message_id: int, pipeline_name: str
-) -> Tuple[int, Optional[str]]:
+    ha_connection: HAConnection, pipeline_name: str
+) -> Optional[str]:
     """Resolves pipeline id by name."""
-    await websocket.send_json(
+    msg = await ha_connection.send_and_receive(
         {
             "type": "assist_pipeline/pipeline/list",
-            "id": message_id,
         }
     )
-    msg = await websocket.receive_json()
     _LOGGER.debug(msg)
-    message_id += 1
 
     pipelines = msg["result"]["pipelines"]
     pipeline_id = _find_pipeline_by_name(
@@ -88,19 +54,17 @@ async def _get_pipeline_id(
     if not pipeline_id:
         _LOGGER.warning("No pipeline named %s in %s", pipeline_name, pipelines)
 
-    return message_id, pipeline_id
+    return pipeline_id
 
 
 async def _start_pipeline(
-    websocket,
-    message_id: int,
+    ha_connection,
     pipeline_id: Optional[str],
     audio_seconds_to_buffer: float = 0.0,
-) -> Tuple[int, int]:
+) -> Tuple[AsyncGenerator[dict, None], int]:
     """Starts Assist pipeline and returns (message id, handler id)"""
     pipeline_args = {
         "type": "assist_pipeline/run",
-        "id": message_id,
         "start_stage": "wake_word",
         "end_stage": "tts",
         "input": {
@@ -111,24 +75,26 @@ async def _start_pipeline(
     }
     if pipeline_id:
         pipeline_args["pipeline"] = pipeline_id
-    await websocket.send_json(pipeline_args)
-    message_id += 1
 
-    msg = await websocket.receive_json()
+    # send_and_receive_many returns a generator of all responses to our message
+    pipeline_events = ha_connection.send_and_receive_many(pipeline_args)
+
+    msg = await pipeline_events.__anext__()
     _LOGGER.debug(msg)
     assert msg["success"], "Pipeline failed to run"
 
     # Get handler id.
     # This is a single byte prefix that needs to be in every binary payload.
-    msg = await websocket.receive_json()
+    msg = await pipeline_events.__anext__()
     _LOGGER.debug(msg)
     handler_id = msg["event"]["data"]["runner_data"]["stt_binary_handler_id"]
 
-    return message_id, handler_id
+    return pipeline_events, handler_id
 
 
 async def _audio_to_events(
-    websocket,
+    ha_connection: HAConnection,
+    pipeline_events: AsyncGenerator[dict, None],
     handler_id: int,
     audio: "asyncio.Queue[Tuple[int, bytes]]",
 ) -> AsyncGenerator[Tuple[int, str, Dict[str, Any]], None]:
@@ -136,7 +102,7 @@ async def _audio_to_events(
     prefix_bytes = bytes([handler_id])
 
     audio_task = asyncio.create_task(audio.get())
-    event_task = asyncio.create_task(websocket.receive())
+    event_task = asyncio.ensure_future(pipeline_events.__anext__())
     pending = {audio_task, event_task}
 
     while True:
@@ -149,7 +115,9 @@ async def _audio_to_events(
             # Forward to websocket
             _timestamp, audio_chunk = audio_task.result()
             pending.add(
-                asyncio.create_task(websocket.send_bytes(prefix_bytes + audio_chunk))
+                asyncio.create_task(
+                    ha_connection.send_bytes(prefix_bytes + audio_chunk)
+                )
             )
 
             # Next audio chunk
@@ -157,15 +125,9 @@ async def _audio_to_events(
             pending.add(audio_task)
 
         if event_task in done:
-            msg = event_task.result()
-            if msg.type != aiohttp.WSMsgType.TEXT:
-                _LOGGER.warning("Unexpected message: %s", msg)
-                continue
+            event = event_task.result()
 
-            event = json.loads(msg.data)
-
-            if event.get("type") != "event":
-                continue
+            assert event["type"] == "event"
 
             _LOGGER.debug(event)
             event_type = event["event"]["type"]
@@ -183,7 +145,7 @@ async def _audio_to_events(
                 break
 
             # Next event
-            event_task = asyncio.create_task(websocket.receive())
+            event_task = asyncio.ensure_future(pipeline_events.__anext__())
             pending.add(event_task)
 
     for task in pending:

--- a/homeassistant_satellite/snd.py
+++ b/homeassistant_satellite/snd.py
@@ -5,7 +5,7 @@ import wave
 from time import sleep
 from typing import TYPE_CHECKING, Any, Dict, Final, Generator, List, Optional
 
-from .mic import APP_NAME
+from .mic_record import APP_NAME
 from .state import State
 
 DEFAULT_APLAY: Final = "aplay -r {rate} -c 1 -f S16_LE -t raw"

--- a/homeassistant_satellite/state.py
+++ b/homeassistant_satellite/state.py
@@ -3,10 +3,13 @@ from enum import Enum, auto
 from typing import Optional
 
 
-class MicState(str, Enum):
+class MicState(int, Enum):
     NOT_RECORDING = auto()
     WAIT_FOR_VAD = auto()
     RECORDING = auto()
+
+    def next(self):
+        return MicState(self.value + 1)
 
 
 @dataclass
@@ -15,3 +18,5 @@ class State:
     mic: MicState = MicState.NOT_RECORDING
     mic_host: Optional[str] = None
     last_event: Optional[str] = None
+    vad_prob: float = 0
+    pipeline_count: int = 0

--- a/homeassistant_satellite/state.py
+++ b/homeassistant_satellite/state.py
@@ -6,6 +6,7 @@ from typing import Optional
 class MicState(int, Enum):
     NOT_RECORDING = auto()
     WAIT_FOR_VAD = auto()
+    WAIT_FOR_WAKE_WORD = auto()
     RECORDING = auto()
 
     def next(self):

--- a/homeassistant_satellite/state.py
+++ b/homeassistant_satellite/state.py
@@ -14,3 +14,4 @@ class State:
     is_running: bool = True
     mic: MicState = MicState.NOT_RECORDING
     mic_host: Optional[str] = None
+    last_event: Optional[str] = None

--- a/homeassistant_satellite/wake_word.py
+++ b/homeassistant_satellite/wake_word.py
@@ -1,0 +1,157 @@
+import logging
+import asyncio
+from asyncio import Queue, AbstractEventLoop
+import os
+from typing import Tuple
+
+_LOGGER = logging.getLogger()
+
+
+class WyomingWakeWordDetector:
+    """Detects wake words using a wyoiming protocol server.
+    
+    This class is used in the mic thread by syncronous code. However the main
+    work is delegated to the async function _run_wyoming which runs in the main thread."""
+
+    def __init__(
+        self, host: str, port: int, wake_word_id: str | None, loop: AbstractEventLoop
+    ):
+        try:
+            import wyoming
+        except ImportError:
+            _LOGGER.fatal("Please pip install homeassistant_satellite[wyoming]")
+            raise
+
+        self._host = host
+        self._port = port
+        self._wake_word_id = wake_word_id
+        self._loop = loop
+        self._detected = False
+        self._queue: Queue | None = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._queue:
+            # we are connected to wyoming, put None in the queue to trigger a disconnect.
+            self._loop.call_soon_threadsafe(self._queue.put_nowait, None)
+
+    async def _run_wyoming(self):
+        from wyoming.audio import AudioChunk, AudioStart
+        from wyoming.client import AsyncTcpClient
+        from wyoming.wake import Detect, Detection
+
+        assert self._queue
+
+        try:
+            _LOGGER.debug(
+                "Connecting to wyoming host=%s port=%s", self._host, self._port
+            )
+
+            async with AsyncTcpClient(self._host, self._port) as client:
+                _LOGGER.debug("Connected to wyoming")
+
+                await client.write_event(
+                    Detect(
+                        names=[self._wake_word_id] if self._wake_word_id else None
+                    ).event()
+                )
+                await client.write_event(
+                    AudioStart(
+                        rate=16000,
+                        width=2,
+                        channels=1,
+                    ).event(),
+                )
+
+                # Read audio and wake events in "parallel"
+                audio_task = asyncio.create_task(self._queue.get())
+                wake_task = asyncio.create_task(client.read_event())
+                pending = {audio_task, wake_task}
+
+                while True:
+                    done, pending = await asyncio.wait(
+                        pending, return_when=asyncio.FIRST_COMPLETED
+                    )
+
+                    if wake_task in done:
+                        event = wake_task.result()
+                        assert event is not None, "Connection to wyoming lost"
+
+                        _LOGGER.debug("Received wyoming event: %s", event)
+
+                        if Detection.is_type(event.type):
+                            # Possible detection
+                            detection = Detection.from_event(event)
+                            _LOGGER.info(detection)
+
+                            if self._wake_word_id and (
+                                detection.name != self._wake_word_id
+                            ):
+                                _LOGGER.warning(
+                                    "Expected wake word %s but got %s, skipping",
+                                    self._wake_word_id,
+                                    detection.name,
+                                )
+                                wake_task = asyncio.create_task(client.read_event())
+                                pending.add(wake_task)
+                                continue
+
+                            self._detected = True
+                            break
+
+                        # Next event
+                        wake_task = asyncio.create_task(client.read_event())
+                        pending.add(wake_task)
+
+                    if audio_task in done:
+                        # Forward audio to wake service
+                        ts_chunk = audio_task.result()
+                        if ts_chunk is None:
+                            break  # a None chunk is instruction to exit
+
+                        timestamp, chunk = ts_chunk
+                        audio_chunk = AudioChunk(
+                            rate=16000,
+                            width=2,
+                            channels=1,
+                            audio=chunk,
+                            timestamp=timestamp,
+                        )
+                        await client.write_event(audio_chunk.event())
+
+                        # Next chunk
+                        audio_task = asyncio.create_task(self._queue.get())
+                        pending.add(audio_task)
+
+        except:
+            _LOGGER.exception("Error running wyoming wake word detection")
+            os._exit(-1)
+
+    @property
+    def detected(self) -> bool:
+        """Allows to query by syncronous code where a detection was already
+        received from the wyoming server."""
+
+        return self._detected
+
+    def reset(self):
+        """After a reset, the next call to process_chunk will start a new
+        wyoming connection."""
+
+        self._detected = False
+        self._queue = None
+
+    def process_chunk(self, ts_chunk: Tuple[int, bytes]):
+        """The first time this function is called a connection to the wyoming
+        server is opened (by scheduling _run_wyoming in the main thread). Then
+        all chunks are forwarded to _run_wyoming via the queue, to be sent to
+        the server.
+        """
+
+        if self._queue is None:
+            self._queue = Queue()
+            asyncio.run_coroutine_threadsafe(self._run_wyoming(), self._loop)
+
+        self._loop.call_soon_threadsafe(self._queue.put_nowait, ts_chunk)


### PR DESCRIPTION
This PR implements wake word detection by forwarding audio to a wyoming server, with the obvious use case of running it locally on the satellite machine.

The alternative "local" approach would be to embed the detector (and of course we can implement both), but I think wyoming has several advantages:
- Possibility to use any wyoming-enabled detector (openWakeWord, porcupine, ...)
- Better abstraction, wyoming hides the details, no need to repackage every detector update, etc.
- We can run openWakeWord on a third machine (neither on the satellite nor on HA) without audio having to pass via HA.


Technical notes:
- This PR builds on top of #29 (to keep conflicts to a minimum). But I could rebase if we want to merge it alone.

- I found that the mic processing (not recording) code (webrtc, vad, wav writer, etc) was a bit hard to follow, cause each step was intefering with the others (eg wav writing had to take into account the webrtc buffer).

  So I rewrote the mic processing logic using a "pipe"-like approach, with clearly independent functions that receive a chunk stream as input and produce a chunk stream as output (with the possibility to modify chunks, buffer them, etc). I put it in a separate `mic_process.py` file, I think you'll like the logic, it's quite clean.

- After this restructuring, adding the wake word logic was quite easy (it's the second commit). The main challenge was to schedule the async wyoming code in the main thread, and have it controlled by sync functions in the mic thread.

I'd be happy to discuss alternative solutions, of course.