### PR TITLE
Include `sounds/` directory in docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !homeassistant_satellite/VERSION
 !homeassistant_satellite/py.typed
 !setup.py
+!sounds/*


### PR DESCRIPTION
The docker image was excluding the `sounds/` directory, making `--awake-sound` and `--done-sound` harder to test.