### PR TITLE
Allow record_pulseaudio to exit when state.is_running == False

### DIFF
--- a/homeassistant_satellite/mic_record.py
+++ b/homeassistant_satellite/mic_record.py
@@ -132,6 +132,9 @@ def _pulseaudio_thread_proc(
                 chunk = pa.read(samples_per_chunk * WIDTH)
                 ts_chunk = (time.monotonic_ns(), chunk)
                 loop.call_soon_threadsafe(queue.put_nowait, ts_chunk)
+
+            # allow the queue consumer to exit
+            loop.call_soon_threadsafe(queue.put_nowait, (time.monotonic_ns(), b""))
     except Exception:
         _LOGGER.exception("Unexpected error in pulseaudio recording thread")
 


### PR DESCRIPTION
When `state.is_running` becomes false, `record_pulseaudio` gets stuck in `await queue.get()`, since no chunk will ever arrive. This one-line PR adds a final empty chunk to allow `record_pulseaudio` to exit.

This issue was causing homeassistant-satellite to get stuck on my system when a HA connection could not be established at startup (normally the satellite should exit in this case).