### PR TITLE
Terminate if pulseaudio recording fails

### DIFF
--- a/homeassistant_satellite/mic_process.py
+++ b/homeassistant_satellite/mic_process.py
@@ -361,6 +361,9 @@ async def mic_task_entry(
         async for ts_chunk in mic_stream:
             recording_queue.put_nowait(ts_chunk)
 
+        if state.is_running:
+            raise Exception("Recording stopped while satellite is running")
+
     except Exception:
         _LOGGER.exception("Unexpected error in mic_task_entry")
         os._exit(-1)  # pylint: disable=protected-access


### PR DESCRIPTION
#53 fixed the issue that pulseaudio recording got stuck when `is_running` is false.

But a similar issue remains: if pulseaudio recording itself breaks (eg pulseaudio is restarted), `record_pulseaudio` waits for chunks that never arrive. This PR fixes this, a chunk with `ts == 0` signals `record_pulseaudio`  to exit, and also `mic_task_entry` fails if recording stops while still running.