### PR TITLE
Add a note on how to start wyoming server to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Use`--volume-multiplier <VM>` to multiply volume by `<VM>` so 2.0 would be twice
 By default wake word detection is performed by forwarding audio to Home Assistant. It is also possible to perform wake word detection using a wyoming server,
 possibly (but not necessarily) running on the same machine as the satellite.
 
+First, ensure you have a wyoming server running. See
+[Wyoming openWakeWord](https://github.com/rhasspy/wyoming-openwakeword) for instructions.
+
 To enable:
 ``` sh
 .venv/bin/pip3 install .[wyoming]


### PR DESCRIPTION
The readme already has a note on how to leverage a wyoming server for wake word detection, however it does not clarify how to start one. This PR adds a link to wyoming-openwakeword repository, which has the additional required instructions.