### PR TITLE
Add dependencies to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Install Python and the required system dependencies:
 
 ``` sh
 sudo apt-get update
-sudo apt-get install python3 python3-pip python3-venv \
-                     alsa-utils git
+sudo apt-get install python3 python3-pip python3-venv python3-dev \
+                     alsa-utils git build-essential
 
 sudo apt-get install --no-install-recommends \
                      ffmpeg


### PR DESCRIPTION
`python3-dev` and `build-essential` packages can be missing on some operating systems like the popular media player OSMC (https://osmc.tv/) 