### PR TITLE
Add a command argument to send all pipeline events to satellite events

### DIFF
--- a/homeassistant_satellite/__main__.py
+++ b/homeassistant_satellite/__main__.py
@@ -160,6 +160,12 @@ async def main() -> None:
     parser.add_argument(
         "--debug", action="store_true", help="Print DEBUG messages to the console"
     )
+    #
+    parser.add_argument(
+        "--send-all-events",
+        action="store_true",
+        help="Report back all received pipeline events to the homeassistant_satellite_event event",
+    )
     args = parser.parse_args()
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
     _LOGGER.debug(args)
@@ -323,9 +329,9 @@ async def _run_pipeline(
         # event to let the world know about our state. Skip consecutive same
         # events (mainly consecutive run-ends).
         if (
-            event_type in ["wake_word-end", "stt-end", "tts-end", "run-end"]
-            and event_type != state.last_event
-        ):
+            args.send_all_events
+            or event_type in ["wake_word-end", "stt-end", "tts-end", "run-end"]
+        ) and event_type != state.last_event:
             state.last_event = event_type
             asyncio.create_task(  # in background
                 ha_connection.send_and_receive(


### PR DESCRIPTION
Hello!
I had a use case a bit like #71 where I wanted to control a matrix to display the current status of the pipeline. But the `homeassistant_satellite_event` was not sending back some events I needed.
Since they are basically all the events it receives from the assist pipeline, I figured an option to send back all events to HA would be the best.
I understand it makes the event very chatty, hence why I put it in an option instead of trying to change the default. I'm sure the filter is there for a reason!


I should explain my exact use case:

Using these events I made a program (could also have made an automation) that subscribes to the `homeassistant_satellite_event` to show on my clock based on the `type` attribute in the event:
- `wake_word-start`: show indicator it's trying to find the wake word
- `wake_word-end`: show a screen to indicate it's waiting for a voice command
- `stt-vad-end`: show that whisper is cooking
- `stt-end`: get the understood text and display it
- `tts-start`: display the text that will be said back
- `intent-end`: display a "confused" icon 

I am not using all events yet but I'm pretty sure they would be useful for related use-cases but I definitely was too limited wiuth only `"wake_word-end", "stt-end", "tts-end", "run-end"` events.

Thank you for considering this!
I am not too used to python so I tried my best, I can change things up if it's a bad implementation.